### PR TITLE
feat(options): apply same styling used on popup to options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "description": "An extension using the Bionic Reading API, to convert text to Bionic Reading ®",
   "version": "0.2.1",
   "manifest_version": 3,
+  "homepage_url": "https://github.com/kwame-mintah/bionic-speed-reader-browser-extension/blob/master/README.md",
   "background": {
     "service_worker": "./src/js/background.js"
   },

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,18 +1,17 @@
 div {
   color: black;
   margin: auto;
-  width: fit-content;
+  max-width: 458px;
   height: fit-content;
   text-align: left;
-  font-size: 1.1em;
 }
 
 body {
-  background-color: white;
+  background-color: #fff;
   margin: auto;
   border: 0px solid black;
   padding: 30px;
-  font-family: monospace;
+  font-family: sans-serif;
 }
 
 p {
@@ -23,20 +22,18 @@ p {
 }
 
 button {
-  background-color: #ffffff;
-  color: black;
-  padding: 5px 5px;
-  border-width: 1px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 20px;
+  background-color: #fff;
+  border: solid 1px #c0c0c0;
+  border-radius: 6px;
+  padding: 7px 11px;
+  color: #484848;
+  margin-right: 2px;
+  font-size: 15px;
 }
 
 #apiKey {
   width: 450px;
   height: 30px;
-  font-family: monospace;
 }
 
 #optionButtons {
@@ -50,4 +47,36 @@ button {
 
 .newFeature b {
   color: red;
+}
+
+.btn-saccade-container {
+  margin-left: 2px;
+}
+
+.btn-fix-container {
+  margin-left: 2px;
+}
+
+.btn-save,
+.btn-preview,
+.btn-clear-storage {
+  background-color: #2e85ff;
+  color: #fff;
+}
+
+.btn-select {
+  background-color: #08c500;
+  color: #fff;
+  border: 1px solid #08c500;
+}
+
+.btn-saved {
+  background-color: #8fbeff;
+  color: #eee;
+}
+
+button.btn-preview:active,
+button.btn-clear-storage:active {
+  background-color: #8fbeff;
+  color: #eee;
 }

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -21,13 +21,13 @@
 
     <div id="fixationOption">
       <h2>Fixation</h2>
-      <label>
+      <div class="btn-fix-container">
         <button id="btn1" value="1">1</button>
         <button id="btn2" value="2">2</button>
         <button id="btn3" value="3">3</button>
         <button id="btn4" value="4">4</button>
         <button id="btn5" value="5">5</button>
-      </label>
+      </div>
       <p>
         With the Fixation you define how much of a word is bold when it is bolded. 1 is half of the word bold and 5 is
         least amount bold.
@@ -36,13 +36,13 @@
 
     <div id="saccadeOption">
       <h2>Saccade</h2>
-      <label>
+      <div class="btn-saccade-container">
         <button id="btn10" value="10">10</button>
         <button id="btn20" value="20">20</button>
         <button id="btn30" value="30">30</button>
         <button id="btn40" value="40">40</button>
         <button id="btn50" value="50">50</button>
-      </label>
+      </div>
       <p>
         With the Saccade you define how common it is for a word to be bolded 10 is every word and 50 is least.
       </p>
@@ -60,7 +60,7 @@
     <div id="experimentalModes">
       <h2>Experimental Features</h2>
       <div id="toggleWebsiteConvert">
-        <p class="newFeature"><b>**New**</b> Convert webpage using page url <b>**New**</b></p>
+        <h3 class="newFeature"><b>**New**</b> Convert webpage using page URL <b>**New**</b></h3>
         <p>
           <u>Recommended:</u> Enabling this option will use the current webpage url, as the content to be used for
           requesting
@@ -80,9 +80,9 @@
     </div>
 
     <div id="optionButtons">
-      <button id="submit">Save</button>
-      <button id="preview">Preview</button>
-      <button id="clear">Clear local storage</button>
+      <button id="submit" class="btn-save">Save</button>
+      <button id="preview" class="btn-preview">Preview</button>
+      <button id="clear" class="btn-clear-storage">Clear local storage</button>
     </div>
   </div>
   <!-- Loaded last, or will not be able get the elements on page -->


### PR DESCRIPTION
# Description

options page has been updated to have the css styling that is present on `popup.html` e.g. updated buttons, font, spacing etc. and add homepage url to project readme documentation.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
