### PR TITLE
ci(github): create github workflow for bumping and creating a new release

### DIFF
--- a/.github/bumpversion.yml
+++ b/.github/bumpversion.yml
@@ -1,0 +1,35 @@
+name: Bump version
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: "Commitizen bump version and create changelog"
+    steps:
+      - name: Get current date
+        id: date
+        run: |
+          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Check out
+        uses: actions/checkout@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          fetch-depth: 0
+      - name: Increment version and generate changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.REVISION }} ${{ env.DATE }}
+          body_path: CHANGELOG.md
+          tag_name: v${{ env.REVISION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

the workflow uses the following actions: `actions/checkout@v2`, `commitizen-tools/commitizen-action@master` and `softprops/action-gh-release@v1`. when the job is triggered, commitizen will increment the package version and also appened to the current changelog and softprops will create a new release for the repository.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
